### PR TITLE
Also replace dashes in front of uppercase chars

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@
 
 module.exports.stringToResourceName = (input) => {
   return input.charAt(0).toUpperCase() + 
-         input.replace(/-([a-z])/g, (g) => { 
+         input.replace(/-([a-zA-Z])/g, (g) => { 
            return g[1].toUpperCase();
          }).slice(1);
 };


### PR DESCRIPTION
[sam local](https://github.com/awslabs/aws-sam-local) currently fails if dashes are present in the resource name.

This change makes it so that dashes in front of uppercase chars are also removed.

For example, a function name called `Serverless-function-Name` will now be renamed to `ServerlessFunctionName` in the resulting sam template.