### PR TITLE
Fixes subfolder handlers for export

### DIFF
--- a/lib/FunctionConverter.js
+++ b/lib/FunctionConverter.js
@@ -32,7 +32,7 @@ class FunctionConverter {
 
   serverlessFunctionToSam(resourceName, serverlessFunction) {
     let handlerArray = serverlessFunction.handler.split(path.sep);
-    const lambdaHandler = handlerArray[handlerArray.length - 1];
+    const lambdaHandler = serverlessFunction.handler;
     handlerArray.pop();
     let codeUri = path.resolve(handlerArray.join(path.sep));
     


### PR DESCRIPTION
Currently, if handlers are located on subfolders from the serverless.yml location, export will ignore subfolders and output a wrong path to handler in the new formed .yml.

This short modification fixes it. 