### PR TITLE
prepend forward slash (/) to http event path before adding the method

### DIFF
--- a/lib/events/HttpEventConverter.js
+++ b/lib/events/HttpEventConverter.js
@@ -57,6 +57,10 @@ class HttpEventConverter {
       http = event;
     }
 
+    if (http.path.charAt(0) != "/") {
+      http.path = "/" + http.path;
+    }
+
     this.addHttpMethod(http, targetResourceName);
 
     this.apiResourceName = Utils.stringToResourceName(this.serverless.service.service);
@@ -84,19 +88,16 @@ class HttpEventConverter {
   }
 
   addHttpMethod(httpConfig, targetResourceName) {
-    let httpPath = httpConfig.path;
-    if (httpPath.charAt(0) != "/") {
-      httpPath = "/" + httpPath;
-    }
+
     let httpMethod = httpConfig.method.toLowerCase();
-    
-    if (!this.apiDefinition.paths[httpPath]) {
-      this.apiDefinition.paths[httpPath] = {};
+
+    if (!this.apiDefinition.paths[httpConfig.path]) {
+      this.apiDefinition.paths[httpConfig.path] = {};
     }
 
-    if (this.apiDefinition.paths[httpPath][httpMethod] && Object.keys(this.apiDefinition.paths[httpPath][httpMethod]).length > 0) {
-      throw new Error("Error while generating Swagger definition: " + 
-        "Method " + httpMethod + " already exists on " + httpPath + " resource");
+    if (this.apiDefinition.paths[httpConfig.path][httpMethod] && Object.keys(this.apiDefinition.paths[httpConfig.path][httpMethod]).length > 0) {
+      throw new Error("Error while generating Swagger definition: " +
+        "Method " + httpMethod + " already exists on " + httpConfig.path + " resource");
     }
 
     let methodConfig = {
@@ -113,7 +114,7 @@ class HttpEventConverter {
     if (httpConfig.cors) {
       let optionsMethod = this.getDefaultOptionsConfig();
       let headers = optionsMethod["x-amazon-apigateway-integration"].responses.default.responseParameters["method.response.header.Access-Control-Allow-Headers"];
-      let methods = Object.keys(this.apiDefinition.paths[httpPath]).concat([httpMethod]).join(",");
+      let methods = Object.keys(this.apiDefinition.paths[httpConfig.path]).concat([httpMethod]).join(",");
       let origins = optionsMethod["x-amazon-apigateway-integration"].responses.default.responseParameters["method.response.header.Access-Control-Allow-Origin"];
       if (typeof(httpConfig.cors) === "object") {
         if (httpConfig.cors.origins) {
@@ -129,7 +130,7 @@ class HttpEventConverter {
       methodConfig["x-amazon-apigateway-integration"]["responses"] = JSON.parse(JSON.stringify(optionsMethod["x-amazon-apigateway-integration"].responses));
       methodConfig.responses = this.getCorsResponses()
 
-      this.apiDefinition.paths[httpPath]["options"] = optionsMethod;
+      this.apiDefinition.paths[httpConfig.path]["options"] = optionsMethod;
     }
 
     if (httpConfig.authorizer && typeof(httpConfig.authorizer) === "string") {
@@ -139,7 +140,7 @@ class HttpEventConverter {
       methodConfig["security"] = [ authConfig ];
     }
 
-    this.apiDefinition.paths[httpPath][httpMethod] = methodConfig;
+    this.apiDefinition.paths[httpConfig.path][httpMethod] = methodConfig;
   }
 
   getApiResourceName() {


### PR DESCRIPTION
In my serverless.yml, I have gateway event paths like `path: my/path` which were being served (unsuccessfully) from `localhost:3000my/path`.

This patch moves the existing logic prefixing "/" a bit earlier in the process. The first two changes are represent the different logic, everything after thatis just because we no longer need a different variable declaration inside `HttpEventConverter~addHttpMethod` since the path gets cleaned up before we call it.

Please let me know if there is anything I can do to help you move this forward.