### PR TITLE
force adding permission resources

### DIFF
--- a/lib/sam/SamBuilder.js
+++ b/lib/sam/SamBuilder.js
@@ -70,7 +70,7 @@ class SamBuilder {
           Principal: 'apigateway.amazonaws.com',
         },
       },
-      false);
+      true);
   }
 
   addOutput(logicalId, obj) {


### PR DESCRIPTION
Handle multiple methods on the same endpoint:
```
functions:
  FooEndpoint:
    handler: index.foor
    events:
      - http:
          path: foo
          method: get
      - http:
          path: foo
          method: post
```

I'm happy to add an integration test for this, but I can't tell where the test data is generated