### PR TITLE
Bug Fix: Supports multiple runtimes within the same serverless.yml

### DIFF
--- a/lib/FunctionConverter.js
+++ b/lib/FunctionConverter.js
@@ -32,7 +32,7 @@ class FunctionConverter {
 
   serverlessFunctionToSam(resourceName, serverlessFunction) {
     let lambdaHandler = serverlessFunction.handler;
-    let codeUri = this.serverless.service.package.artifact;
+    const codeUri = this.getCodeUri(serverlessFunction);
 
     // looks like this is not required. Commenting out for the time being
     /*if (!codeUri) {
@@ -45,7 +45,7 @@ class FunctionConverter {
     // begin building the function object
     let samFunctionBuilder = this.samBuilder.addFunction(resourceName);
 
-    const runtime = this.serverless.service.provider.runtime;
+    const runtime = this.getRuntime(serverlessFunction);
 
     samFunctionBuilder = samFunctionBuilder.withCodeUri(codeUri).withRuntime(runtime).withHandler(lambdaHandler);
 
@@ -122,6 +122,20 @@ class FunctionConverter {
 
   isEventEnabled(event) {
     return event.enabled === undefined || event.enabled;
+  }
+
+  getCodeUri(serverlessFunction) {
+    //Check to see if the artifact has been overwritten in the function.
+    if (serverlessFunction && serverlessFunction.package && serverlessFunction.package.artifact) {
+      return serverlessFunction.package.artifact;
+    }
+
+    return this.serverless.service.package.artifact;
+  }
+
+  getRuntime(serverlessFunction) {
+    //Check to see if the runtime has been overwritten in the function.
+    return serverlessFunction.runtime || this.serverless.service.provider.runtime;
   }
 }
 


### PR DESCRIPTION
Submitting this PR to fix an issue I've encountered.

In my example, all my functions are written in Java however I had a use-case where I need one function written in NodeJS.

To get it to work with Serverless, I need to do the following:

- Set `runtime: java8` under `provider`.
- Set the `artifact` under the top-level `package` to the path of jar file for my Java functions.
- Add the following under the NodeJS function:
```
package:
      individually: true
      artifact: node/package.zip
runtime: nodejs6.10
```

With these changes, everything works as expected when I deploy to AWS, however when I exported the SAM template and attempted to run it locally using `sam local-api` it would try to execute the NodeJS handler using the Java image.

The reason for this is that the code that gets the `Runtime` and `CodeUri` doesn't take into account parameters defined at a function-level.

I've put in a simple fix to give precedence to the runtime and artifact set at a function level over the top-level runtime / artifact.