### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ class SamPlugin {
                   + '(e.g. "--output ./sam-template.yml" or "-o ./sam-template.yml")',
                 required: true,
                 shortcut: 'o',
+                type: 'string',
               },
             },
           }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - SamPlugin for "output"
```